### PR TITLE
bug: resolving issue with missing export in strapi v4.15.4

### DIFF
--- a/admin/src/components/DuplicateButton/index.js
+++ b/admin/src/components/DuplicateButton/index.js
@@ -1,10 +1,9 @@
 import React from "react";
 import { useIntl } from "react-intl";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { Button } from "@strapi/design-system/Button";
 import Duplicate from "@strapi/icons/Duplicate";
 import { useCMEditViewDataManager } from "@strapi/helper-plugin";
-import usePluginsQueryParams from "@strapi/admin/admin/src/content-manager/hooks/usePluginsQueryParams";
 
 const DuplicateButton = () => {
   const { modifiedData, layout, isSingleType } = useCMEditViewDataManager();
@@ -15,14 +14,14 @@ const DuplicateButton = () => {
   } = useHistory();
 
   const { formatMessage } = useIntl();
-  const pluginsQueryParams = usePluginsQueryParams();
+  const { search } = useLocation();
 
   const handleDuplicate = () => {
     const copyPathname = pathname.replace(layout.uid, `${layout.uid}/create/clone`);
     push({
       pathname: copyPathname,
       state: { from: pathname },
-      search: pluginsQueryParams,
+      search: search,
     });
   };
 


### PR DESCRIPTION
Latest versions of strapi (v4.15.2 onwards) have removed the export for `usePluginsQueryParams` that this library depended on. The strapi team have recommended in light of this change that plugins not utilise internal strapi exports in this way as they cannot guarantee that that they will be consistently available in future versions.

This PR addresses the issue by swapping `usePluginsQueryParams` for `useLocation` from `react-router-dom@v5`.

See discussion: strapi/strapi#18711