### PR TITLE
Add GitHub Link to package.json for Compatibility with patch-package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "strapi-plugin-duplicate-button",
   "version": "1.3.16",
   "description": "Adds a Duplicate Button to the edit view",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lautr/strapi-plugin-duplicate-button.git"
+  },
   "strapi": {
     "name": "duplicate-button",
     "description": "Adds a Duplicate Button to the edit view",


### PR DESCRIPTION
This pull request adds a repository field to the `package.json file`, including this project's GitHub link. This change is necessary for users utilizing the [patch-package](https://www.npmjs.com/package/patch-package) library to create patches that reference the repository link correctly.

### Changes:
I added the repository field in package.json to the GitHub URL.
This ensures patch-package functions as expected when creating and applying patches.
Reason for the Change:
The patch-package library relies on the repository field in package.json to correctly reference and apply patches for dependencies. 

Without this field, users may encounter issues when trying to patch this package in their projects with the following message:
```
{
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 34008,
  stdout: null,
  stderr: null,
  error: null
}
```

Example of the New package.json Entry:

```json
{
  "repository": {
    "type": "git",
    "url": "https://github.com/lautr/strapi-plugin-duplicate-button.git"
  }
}
```

### Testing:
Validated that the patch-package library now correctly references the repository when applying patches.

### Additional Notes:
This is a non-breaking change and should not affect any other part of the project.

Please let me know if you need further adjustments or additional details!